### PR TITLE
[Added Feature] Optional defualt index page for the "serve" method

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,18 @@ app.serve("mystaticfolder", "/public");
 // A GET request to /public/test.txt would serve the local file at mystaticfolder/test.txt
 ```
 
+(Optional) Static route with default index page
+
+You could define a default index page for your static routes such as `index.html`
+
+```typescript
+app.serve("mystaticfolder", "/", {
+  index: "index.html",
+});
+```
+
+so when a user requests `/`, the server will serve the file `mystaticfolder/index.html`
+
 ### Regex paths
 
 You can provide a RegExp object instead of a string and receive the matches.

--- a/aqua.ts
+++ b/aqua.ts
@@ -422,7 +422,7 @@ export default class Aqua {
 
       return {
         headers: contentType ? { "Content-Type": contentType } : undefined,
-        content: await Deno.readFile(`${folder}/${requestedPath}`),
+        content: await Deno.readFile(`${folder}/${resourcePath}`),
       };
     } catch {
       return await this.getFallbackHandlerResponse(


### PR DESCRIPTION
Allowing users to define a default index page such as `index.html` when creating a new static route

Example:
```typescript
app.serve("public", "/", {
  index: "index.html",
});
```
```
GET /

OK 200
<index.html>
```
